### PR TITLE
Add feedback page with Baserow integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_BASEROW_EMAIL=deeprajchouhan012@gmail.com
+VITE_BASEROW_PASSWORD=Deepraj@123

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import HomePage1 from "./pages/HomePage1"
 import HomePage2 from "./pages/HomePage2"
 import HomePage3 from "./pages/HomePage3"
 import BlogDetails from "./pages/BlogDetails"
+import FeedbackPage from "./pages/FeedbackPage"
 
 function App() {
 
@@ -13,6 +14,7 @@ function App() {
         <Route path="/home-2" element={<HomePage2/>}/>
         <Route path="/home-3" element={<HomePage3/>}/>
         <Route path="/blog-details" element={<BlogDetails/>}/>
+        <Route path="/feedback" element={<FeedbackPage/>}/>
       </Routes>
     </Router>
   )

--- a/src/components/feedback/FeedbackSection.jsx
+++ b/src/components/feedback/FeedbackSection.jsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+
+const FeedbackSection = () => {
+  const [name, setName] = useState('')
+  const [type, setType] = useState('feature')
+  const [feedback, setFeedback] = useState('')
+  const [status, setStatus] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setStatus('')
+    try {
+      const email = import.meta.env.VITE_BASEROW_EMAIL
+      const password = import.meta.env.VITE_BASEROW_PASSWORD
+
+      const authRes = await fetch('https://api.baserow.io/api/user/token-auth/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      const authData = await authRes.json()
+      if (!authRes.ok) throw new Error(authData.detail || 'Authentication failed')
+      const token = authData.token
+
+      const dbRes = await fetch('https://api.baserow.io/api/database/databases/', {
+        headers: { Authorization: `Token ${token}` }
+      })
+      const dbData = await dbRes.json()
+      const db = dbData.results.find(d => d.name === 'portfolio')
+      if (!db) throw new Error('Database not found')
+
+      const tableRes = await fetch(`https://api.baserow.io/api/database/tables/database/${db.id}/`, {
+        headers: { Authorization: `Token ${token}` }
+      })
+      const tableData = await tableRes.json()
+      const table = tableData.results.find(t => t.name === 'feedback')
+      if (!table) throw new Error('Table not found')
+
+      const rowRes = await fetch(`https://api.baserow.io/api/database/rows/table/${table.id}/?user_field_names=true`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Token ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ Name: name, Type: type, Feedback: feedback })
+      })
+      if (!rowRes.ok) throw new Error('Failed to submit feedback')
+      setStatus('Thanks for your feedback!')
+      setName('')
+      setType('feature')
+      setFeedback('')
+    } catch (err) {
+      setStatus(err.message)
+    }
+  }
+
+  return (
+    <div className="contact-content">
+      <div className="container">
+        <div className="row justify-content-center">
+          <div className="col-xl-6 col-lg-5">
+            <h2 className="section-title title-center">send <span>feedback</span></h2>
+          </div>
+        </div>
+        <div className="row g-0 justify-content-center">
+          <div className="col-lg-6 col-md-7 col-sm-6">
+            <form className="contact-form" onSubmit={handleSubmit}>
+              <div className="form-group">
+                <label>Your full name</label>
+                <input type="text" value={name} onChange={e => setName(e.target.value)} required />
+              </div>
+              <div className="form-group">
+                <label>Type</label>
+                <select value={type} onChange={e => setType(e.target.value)} required>
+                  <option value="feature">Feature</option>
+                  <option value="bug">Bug</option>
+                </select>
+              </div>
+              <div className="form-group">
+                <label>Write your feedback</label>
+                <textarea value={feedback} onChange={e => setFeedback(e.target.value)} required></textarea>
+              </div>
+              <button className="def-btn" type="submit">Submit Feedback</button>
+              {status && <p>{status}</p>}
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default FeedbackSection

--- a/src/components/header/HeaderSection.jsx
+++ b/src/components/header/HeaderSection.jsx
@@ -23,6 +23,7 @@ const HeaderSection = () => {
             </div>
             <div className="col-6">
                 <div className="nav-btn">
+                    <Link className="theme-btn" to="/feedback">Feedback</Link>
                     <a className="theme-btn" role='button' onClick={toggleRtlMode}>{isRtlMode? 'LTR':'RTL'}</a>
                     <a role="button" id="sidebar" onClick={openSidebarSection}><i className="fa-thin fa-gear"></i></a>
                 </div>

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -1,0 +1,17 @@
+import HeaderSection from '../components/header/HeaderSection'
+import FooterSection from '../components/footer/FooterSection'
+import SettingsSidebar from '../components/sidebar/SettingsSidebar'
+import FeedbackSection from '../components/feedback/FeedbackSection'
+
+const FeedbackPage = () => {
+  return (
+    <div className='root-layout'>
+      <HeaderSection/>
+      <FeedbackSection/>
+      <FooterSection/>
+      <SettingsSidebar/>
+    </div>
+  )
+}
+
+export default FeedbackPage


### PR DESCRIPTION
## Summary
- add header link and router entry for new feedback page
- implement feedback form that posts to Baserow
- provide sample environment variables for Baserow credentials

## Testing
- `npm run lint` *(fails: React defined but never used, children prop missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfeb66a45c8323aa038b80dd662e54