### PR TITLE
Align feedback dropdown styling with other form fields

### DIFF
--- a/public/assets/css/style-dark.css
+++ b/public/assets/css/style-dark.css
@@ -212,7 +212,9 @@ body {
   .contact .contact-content .contact-form .form-group label {
     background: #203255;
     color: #bfbfbf; }
-  .contact .contact-content .contact-form .form-group input, .contact .contact-content .contact-form .form-group textarea {
+  .contact .contact-content .contact-form .form-group input,
+  .contact .contact-content .contact-form .form-group select,
+  .contact .contact-content .contact-form .form-group textarea {
     background: #203255;
     color: #d8d8d8;
     border-color: rgba(255, 255, 255, 0.2); }

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -4882,7 +4882,9 @@ textarea {
   z-index: 2;
 }
 
-.contact .contact-content .contact-form .form-group input {
+
+.contact .contact-content .contact-form .form-group input,
+.contact .contact-content .contact-form .form-group select {
   width: 100%;
   height: 40px;
   line-height: 38px;
@@ -4895,11 +4897,13 @@ textarea {
   transition: .3s;
 }
 
-.contact .contact-content .contact-form .form-group input .option.disabled {
+.contact .contact-content .contact-form .form-group select option.disabled {
   display: none;
 }
 
-.contact .contact-content .contact-form .form-group input:focus {
+
+.contact .contact-content .contact-form .form-group input:focus,
+.contact .contact-content .contact-form .form-group select:focus {
   border-color: #CB26B6;
 }
 


### PR DESCRIPTION
## Summary
- Style feedback form `<select>` to match inputs
- Include dark theme styling for dropdown

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 135 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c01f0322708323b8927bae2c182d37